### PR TITLE
Add master name to master requirements tooltip

### DIFF
--- a/components/MastersBadge.tsx
+++ b/components/MastersBadge.tsx
@@ -3,26 +3,37 @@ import { Badge } from "./ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { masterColors, masterIcons, masterNames } from "./MastersHelper";
 
-type MastersBadgeProps = {
+interface TooltipFunctionArgs {
+  masterName: string;
+}
+
+interface MastersBadgeProps {
   master: string;
   text?: string;
-  tooltip?: string | ReactNode;
-};
+  tooltip?: (args: TooltipFunctionArgs) => string | ReactNode;
+}
 
 export const MastersBadge: FC<MastersBadgeProps> = ({
   master,
   text,
   tooltip,
-}) => (
-  <Tooltip>
-    <TooltipTrigger asChild>
-      <Badge variant={"outline"} className={`mr-2 ${masterColors[master]}`}>
-        {masterIcons[master]} {text}
+}) => {
+  const [name, icon, color] = [
+    masterNames[master],
+    masterIcons[master],
+    masterColors[master],
+  ];
 
-      </Badge>
-    </TooltipTrigger>
-    <TooltipContent side="bottom">
-      {tooltip ?? masterNames[master]}
-    </TooltipContent>
-  </Tooltip>
-);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant="outline" className={`mr-2 ${color}`}>
+          {icon} {text}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {tooltip?.({ masterName: name }) ?? name}
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/components/MastersRequirementsBar/components/MastersBadgeRequirementTooltip.tsx
+++ b/components/MastersRequirementsBar/components/MastersBadgeRequirementTooltip.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 
 interface MastersBadgeTooltipProps {
   master: string;
+  name: string;
   all: MasterRequirement[];
   fulfilled: MasterRequirement[];
 }
@@ -11,9 +12,11 @@ interface MastersBadgeTooltipProps {
 export const MastersBadgeRequirementTooltip: FC<MastersBadgeTooltipProps> = ({
   master,
   all,
+  name,
   fulfilled,
 }) => (
   <div className="flex flex-col gap-2 mt-2 mb-2">
+    <p className="font-semibold">{name}</p>
     {all.map((requirement, i) => (
       <MastersRequirementRowRenderer
         key={`${master}-requirement-row-${i}`}
@@ -61,10 +64,7 @@ const MastersRequirementRowRenderer = <T extends MasterRequirement>({
       {isFulfilled ? (
         <LucideCircleCheck color="var(--color-emerald-500)" size={16} />
       ) : (
-        <LucideCircleDashed
-          className="dark:text-background"
-          size={16}
-        />
+        <LucideCircleDashed className="dark:text-background" size={16} />
       )}
       <RequirementRow requirement={requirement} />
     </div>

--- a/components/MastersRequirementsBar/index.tsx
+++ b/components/MastersRequirementsBar/index.tsx
@@ -25,13 +25,14 @@ export const MastersRequirementsBar = () => {
               key={master}
               master={master}
               text={`${progress}%`}
-              tooltip={
+              tooltip={({ masterName }) => (
                 <MastersBadgeRequirementTooltip
                   master={master}
+                  name={masterName}
                   fulfilled={fulfilled}
                   all={masterRequirements[master]}
                 />
-              }
+              )}
             />
           );
         })}


### PR DESCRIPTION
Currently, the master requirements tooltip only shows the requirements. This adds so it now also shows the master's name at the top before that to make it more clear to the user which master the requirements are for.