### PR TITLE
Fix gap when there are only one study type

### DIFF
--- a/components/CourseModal/DialogTimeChart.tsx
+++ b/components/CourseModal/DialogTimeChart.tsx
@@ -48,7 +48,7 @@ const DialogTimeChart = ({ scheduledHours, selfStudyHours } : DialogTimeChartPro
                     endAngle={360 + 90}
                     innerRadius={53}
                     outerRadius={75}
-                    paddingAngle={3}
+                    paddingAngle={data.find(data => data.hours == 0) ? 0 : 3}
                     isAnimationActive
                     animationBegin={120}
                     animationDuration={700}


### PR DESCRIPTION
Go from
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/6cce148c-d2c1-444a-b648-031a52d92ce1" />
To
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/6d948559-ed98-42bd-a46a-54affbe7510f" />
