### PR TITLE
Fix inconsistent dropdown interaction with elective groups in guide

### DIFF
--- a/app/guide/components/ElectiveSelector.tsx
+++ b/app/guide/components/ElectiveSelector.tsx
@@ -72,13 +72,17 @@ const ElectiveSelector: FC<ElectiveSelectorProps> = ({
                 <Button
                   size="icon"
                   className={`cursor-pointer h-10 w-10 rounded-full transition-colors ${
-                    isFulfilled
-                      ? "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-700"
-                      : "bg-amber-500/10 hover:bg-amber-500/20 text-amber-700"
+                    !isOpen
+                      ? "bg-red-500/10 hover:bg-red-500/20 text-red-700"
+                      : isFulfilled
+                        ? "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-700"
+                        : "bg-amber-500/10 hover:bg-amber-500/20 text-amber-700"
                   }`}
                   disabled={!isFulfilled && isOpen}
                 >
-                  {isFulfilled ? (
+                  {!isOpen ? (
+                    <X className="h-4 w-4" />
+                  ) : isFulfilled ? (
                     <Check className="h-4 w-4" />
                   ) : (
                     <X className="h-4 w-4" />


### PR DESCRIPTION
Solves #174.

When closed now: 

<img width="1389" height="217" alt="image" src="https://github.com/user-attachments/assets/c710854d-f4bd-44da-97cf-baa0001fbb8e" />

When opened and not fulfilled:

<img width="1382" height="437" alt="image" src="https://github.com/user-attachments/assets/988330ba-463a-41e3-9e4c-1d104c7718b8" />

When open and fulfilled:

<img width="1371" height="408" alt="image" src="https://github.com/user-attachments/assets/072968d9-c762-46a7-9643-1aaf7302ae48" />
